### PR TITLE
Remove uso da classe legada de parâmetros de pesquisa

### DIFF
--- a/ieducar/intranet/educar_cliente_cad.php
+++ b/ieducar/intranet/educar_cliente_cad.php
@@ -86,14 +86,20 @@ return new class extends clsCadastro {
 
         // Caso o cliente não exista, exibe um campo de pesquisa, senão, mostra um rótulo
         if (!$this->cod_cliente) {
-            $parametros = new clsParametrosPesquisas();
-            $parametros->setSubmit(0);
-            $parametros->adicionaCampoSelect('ref_idpes', 'idpes', 'nome');
-            $parametros->setPessoa('F');
-            $parametros->setPessoaCPF('N');
-            $parametros->setCodSistema(null);
-            $parametros->setPessoaNovo('S');
-            $parametros->setPessoaTela('frame');
+            $parametros = [
+                'submit' => 0,
+                'campo_nome' => ['ref_idpes'],
+                'campo_tipo' => ['select'],
+                'campo_indice' => ['idpes'],
+                'campo_valor' => ['nome'],
+                'pessoa' => 'F',
+                'pessoa_novo' => 'S',
+                'pessoa_tela' => 'frame',
+                'pessoa_campo' => null,
+                'pessoa_editar' => null,
+                'ref_cod_sistema' => null,
+                'pessoa_cpf' => 'N',
+            ];
 
             $dados = [
         'nome' => 'Cliente',
@@ -108,7 +114,7 @@ return new class extends clsCadastro {
         'pag_cadastro' => null,
         'disabled' => '',
         'div' => false,
-        'serializedcampos' => $parametros->serializaCampos(),
+        'serializedcampos' => urlencode(serialize($parametros)),
         'duplo' => false,
         'obrigatorio' => true
       ];

--- a/ieducar/intranet/educar_definir_cliente_tipo_lst.php
+++ b/ieducar/intranet/educar_definir_cliente_tipo_lst.php
@@ -69,14 +69,21 @@ return new class extends clsListagem {
 
         $opcoes = [ '' => 'Pesquise a pessoa clicando na lupa ao lado' ];
 
-        $parametros = new clsParametrosPesquisas();
-        $parametros->setSubmit(0);
-        $parametros->adicionaCampoSelect('ref_idpes', 'idpes', 'nome');
-        $parametros->setCodSistema(1);
-        $parametros->setPessoa('F');
-        $parametros->setPessoaEditar('N');
-        $parametros->setPessoaNovo('N');
-        $this->campoListaPesq('ref_idpes', 'Cliente', $opcoes, $this->ref_idpes, 'pesquisa_pessoa_lst.php', '', false, '', '', null, null, '', false, $parametros->serializaCampos());
+        $parametros = [
+            'submit' => 0,
+            'campo_nome' => ['ref_idpes'],
+            'campo_tipo' => ['select'],
+            'campo_indice' => ['idpes'],
+            'campo_valor' => ['nome'],
+            'pessoa' => 'F',
+            'pessoa_novo' => 'N',
+            'pessoa_tela' => null,
+            'pessoa_campo' => null,
+            'pessoa_editar' => 'N',
+            'ref_cod_sistema' => 1,
+            'pessoa_cpf' => null,
+        ];
+        $this->campoListaPesq('ref_idpes', 'Cliente', $opcoes, $this->ref_idpes, 'pesquisa_pessoa_lst.php', '', false, '', '', null, null, '', false, urlencode(serialize($parametros)));
 
         // Paginador
         $this->limite = 20;

--- a/ieducar/intranet/educar_pagamento_multa_lst.php
+++ b/ieducar/intranet/educar_pagamento_multa_lst.php
@@ -67,12 +67,20 @@ return new class extends clsListagem {
 
         $this->addCabecalhos($lista_busca);
 
-        $parametros = new clsParametrosPesquisas();
-        $parametros->setSubmit(0);
-        $parametros->adicionaCampoSelect('ref_idpes', 'idpes', 'nome');
-        $parametros->setPessoa('F');
-        $parametros->setPessoaCPF('N');
-        $parametros->setCodSistema(1);
+        $parametros = [
+            'submit' => 0,
+            'campo_nome' => ['ref_idpes'],
+            'campo_tipo' => ['select'],
+            'campo_indice' => ['idpes'],
+            'campo_valor' => ['nome'],
+            'pessoa' => 'F',
+            'pessoa_novo' => null,
+            'pessoa_tela' => null,
+            'pessoa_campo' => null,
+            'pessoa_editar' => null,
+            'ref_cod_sistema' => 1,
+            'pessoa_cpf' => 'N',
+        ];
 
         $dados = [
       'nome' => 'Cliente',
@@ -87,7 +95,7 @@ return new class extends clsListagem {
       'pag_cadastro' => null,
       'disabled' => '',
       'div' => false,
-      'serializedcampos' => $parametros->serializaCampos(),
+      'serializedcampos' => urlencode(serialize($parametros)),
       'duplo' => false,
       'obrigatorio' => true
     ];


### PR DESCRIPTION
**Contexto:** As telas de cliente, dívidas e definição de tipo de cliente usavam a classe legada `clsParametrosPesquisas` para montar os parâmetros do campo de pesquisa de pessoa.

**O que foi feito:** As telas passam a montar diretamente o array de parâmetros que é serializado na URL, sem depender da classe. O conteúdo enviado permanece o mesmo.
